### PR TITLE
Exhentai Cookie Tutorial replaced

### DIFF
--- a/version/gui_constants.py
+++ b/version/gui_constants.py
@@ -169,16 +169,13 @@ TOOLTIP_DATE_ADDED = get(True, 'Visual', 'tooltip date added', bool)
 EXHEN_COOKIE_TUTORIAL =\
 	"""
 How do you find these two values? <br \>
-<b>Firefox:</b> <br \>
+<b>Firefox/Chrome/Others</b> <br \>
 1. Navigate to exhentai.org <br \>
-2. Press Shift + F2 (A console should appear below) <br \>
-3. Write: cookie list <br \>
-4. A popup should appear with a list over active cookies <br \>
-5. Look for the 'ipb_member_id' and 'ipb_hash_pass' values <br \>
-<br \>
-<b>Other browsers</b> <br \>
-1. Download a cookie manager (google it) <br \>
-2. look for the 'ipb_member_id' and 'ipb_hash_pass' values in exhentai cookies
+2. Right click --> Inspect element <br \>
+3. Go on 'Console' tab <br \>
+4. Write : 'document.cookie' <br \>
+5. A line of values should appear that correspond to active cookies <br \>
+6. Look for the 'ipb_member_id' and 'ipb_hash_pass' values <br \>
 """
 
 GPL =\


### PR DESCRIPTION
No need to download any extension, with a simple JavaScript query, we can get the cookies ( works everywhere ).
