### PR TITLE
Fixing fetching crush if gallery contained non-image file.

### DIFF
--- a/version/gallerydb.py
+++ b/version/gallerydb.py
@@ -1225,7 +1225,7 @@ class HashDB(DBBase):
 			try:
 				if gallery.is_archive:
 					raise NotADirectoryError
-				imgs = sorted([x.path for x in scandir.scandir(chap.path)])
+				imgs = sorted([x.path for x in scandir.scandir(chap.path) if utils.is_image(x.path)])
 				pages = {}
 				for n, i in enumerate(imgs):
 					pages[n] = i

--- a/version/utils.py
+++ b/version/utils.py
@@ -1201,3 +1201,19 @@ def timeit(func):
 		print('function [{}] finished in {} ms'.format(
 			func.__name__, int(elapsedTime * 1000)))
 	return newfunc
+
+
+def is_image(path):
+	"""
+	Return True if filepath ends with image extension, False if doesn't
+
+	:param path: file path
+	:return: bool
+	"""
+
+	formats = (".jpg", "jpeg", "gif", ".png")
+
+	for formatEntry in formats:
+		if path.endswith(formatEntry):
+			return True
+	return False


### PR DESCRIPTION
I've done some research. The problem here #135 was in "Thumbs.db" file, that windows generate automatically.

gallerydb.py, 1228 line
`imgs = sorted([x.path for x in scandir.scandir(chap.path)])`
This also gets files of any types. And then it breaks here:
`utils.image_greyscale(imgs[0]):`

I fixed it here, but may be there are other places that need this check.
