### PR TITLE
chg: dev: use dict to determine dl type text.

### DIFF
--- a/version/app_constants.py
+++ b/version/app_constants.py
@@ -55,6 +55,11 @@ unrar_tool_path = get('', 'Application', 'unrar tool path')
 DOWNLOAD_TYPE_ARCHIVE = 0
 DOWNLOAD_TYPE_TORRENT = 1 # Note: With this type, file will be sent to torrent program
 DOWNLOAD_TYPE_OTHER = 2
+DOWNLOAD_TYPE_DICT_CONSTANT = {
+    DOWNLOAD_TYPE_ARCHIVE: 'Archive',
+    DOWNLOAD_TYPE_TORRENT: 'Torrent',
+    DOWNLOAD_TYPE_OTHER: 'Other'
+}
 
 VALID_GALLERY_CATEGORY = (
     'Doujinshi',

--- a/version/io_misc.py
+++ b/version/io_misc.py
@@ -88,16 +88,25 @@ class GalleryDownloaderItem(QObject):
         self.cost_item.setToolTip(url)
         self.size_item = QTableWidgetItem(self.item.size)
         self.size_item.setToolTip(url)
-        if hitem.download_type in app_constants.DOWNLOAD_TYPE_DICT_CONSTANT:
-            type_ = app_constants.DOWNLOAD_TYPE_DICT_CONSTANT[hitem.download_type]
-        else:
-            type_ = 'Unknown'
+        type_ = self.get_item_download_type(item=hitem)
         self.type_item = QTableWidgetItem(type_)
         self.type_item.setToolTip(url)
 
         self.status_timer = QTimer()
         self.status_timer.timeout.connect(self.check_progress)
         self.status_timer.start(500)
+
+    @staticmethod
+    def get_item_download_type(item):
+        """get item's download type."""
+        # compatibility
+        hitem = item
+
+        if hitem.download_type in app_constants.DOWNLOAD_TYPE_DICT_CONSTANT:
+            type_ = app_constants.DOWNLOAD_TYPE_DICT_CONSTANT[hitem.download_type]
+        else:
+            type_ = 'Unknown'
+        return type_
 
     def check_progress(self):
         if self.item.current_state == self.item.DOWNLOADING:

--- a/version/io_misc.py
+++ b/version/io_misc.py
@@ -88,14 +88,11 @@ class GalleryDownloaderItem(QObject):
         self.cost_item.setToolTip(url)
         self.size_item = QTableWidgetItem(self.item.size)
         self.size_item.setToolTip(url)
-        _type = 'Unknown'
-        if hitem.download_type == app_constants.DOWNLOAD_TYPE_ARCHIVE:
-            _type = 'Archive'
-        if hitem.download_type == app_constants.DOWNLOAD_TYPE_OTHER:
-            _type = 'Other'
-        if hitem.download_type == app_constants.DOWNLOAD_TYPE_TORRENT:
-            _type = 'Torrent'
-        self.type_item = QTableWidgetItem(_type)
+        if hitem.download_type in app_constants.DOWNLOAD_TYPE_DICT_CONSTANT:
+            type_ = app_constants.DOWNLOAD_TYPE_DICT_CONSTANT[hitem.DOWNLOAD_TYPE]
+        else:
+            type_ = 'Unknown'
+        self.type_item = QTableWidgetItem(type_)
         self.type_item.setToolTip(url)
 
         self.status_timer = QTimer()

--- a/version/io_misc.py
+++ b/version/io_misc.py
@@ -89,7 +89,7 @@ class GalleryDownloaderItem(QObject):
         self.size_item = QTableWidgetItem(self.item.size)
         self.size_item.setToolTip(url)
         if hitem.download_type in app_constants.DOWNLOAD_TYPE_DICT_CONSTANT:
-            type_ = app_constants.DOWNLOAD_TYPE_DICT_CONSTANT[hitem.DOWNLOAD_TYPE]
+            type_ = app_constants.DOWNLOAD_TYPE_DICT_CONSTANT[hitem.download_type]
         else:
             type_ = 'Unknown'
         self.type_item = QTableWidgetItem(type_)


### PR DESCRIPTION
small improvement for dl type text. when new dl type added, the dl type text can be added on dict constant, directly below that.

also using `type_` instead of `_type` to avoid python keyword (based on pep8)

>single_trailing_underscore_ : used by convention to avoid conflicts with Python keyword, e.g.

https://www.python.org/dev/peps/pep-0008/